### PR TITLE
fix: add protection for null comRef

### DIFF
--- a/projects/ngneat/overview/src/lib/views/comp-ref.ts
+++ b/projects/ngneat/overview/src/lib/views/comp-ref.ts
@@ -77,7 +77,7 @@ export class CompRef<T> implements ViewRef {
   }
 
   destroy() {
-    this.compRef.destroy();
+    this.compRef && this.compRef.destroy();
     !this.args.vcr && this.args.appRef.detachView(this.compRef.hostView);
     this.compRef = null;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [V] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[V] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Because we're using the ngDoCheck hook there are cases that it has been called multiple times. For ex. when a loader component appears more than once upon user event. The comRef is getting cleared at the first time and when it calls it again we're getting an error.

Issue Number: N/A

## What is the new behavior?

Added protection in onDestroy to verify there is an instance of comRef before destroying it.

## Does this PR introduce a breaking change?

```
[ ] Yes
[V] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
