### PR TITLE
fix: deduplicate outlet emissions to prevent content being rendered twice

### DIFF
--- a/projects/ngneat/overview/src/lib/teleport/teleport.service.ts
+++ b/projects/ngneat/overview/src/lib/teleport/teleport.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, ViewContainerRef } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { filter, map, startWith } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, startWith } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -16,7 +16,8 @@ export class TeleportService {
       // registered outlet is visible to new subscribers.
       startWith(name),
       filter((current) => current === name),
-      map((name) => this.ports.get(name))
+      map((name) => this.ports.get(name)),
+      distinctUntilChanged()
     );
   }
 

--- a/projects/ngneat/overview/src/lib/teleport/teleport.spec.ts
+++ b/projects/ngneat/overview/src/lib/teleport/teleport.spec.ts
@@ -239,6 +239,46 @@ describe('TeleportDirective', () => {
     });
   });
 
+  describe('Content duplication regression (v8.0.0)', () => {
+    // Regression: when the outlet is already registered by the time teleportTo
+    // subscribes, outlet$() emits twice synchronously — once from startWith() and
+    // once from the BehaviorSubject replaying its current value — both matching the
+    // filter, causing createEmbeddedView to be called twice (content duplicated).
+    @Component({
+      template: `
+        <section>
+          <ng-container teleportOutlet="dup-outlet"></ng-container>
+        </section>
+        <div *teleportTo="'dup-outlet'">content</div>
+      `,
+      imports: [TeleportDirective, TeleportOutletDirective],
+    })
+    class TestComponent {}
+
+    const createComponent = createComponentFactory({
+      component: TestComponent,
+      providers: [provideZonelessChangeDetection()],
+    });
+
+    it('should render teleported content exactly once on first render, not twice', () => {
+      const spectator = createComponent();
+      const divs = spectator.query('section')!.querySelectorAll('div');
+      expect(divs.length).toBe(1);
+    });
+
+    it('should not add content again when the component is recreated (simulated route revisit)', () => {
+      // First visit
+      const spectator1 = createComponent();
+      spectator1.fixture.destroy();
+
+      // Second visit — TeleportService is still alive (providedIn: root), BehaviorSubject
+      // still holds the last outlet name, so the duplicate-emission bug fires again.
+      const spectator2 = createComponent();
+      const divs = spectator2.query('section')!.querySelectorAll('div');
+      expect(divs.length).toBe(1);
+    });
+  });
+
   describe('Asynchronous behavior', () => {
     @Component({
       selector: 'app-hello',


### PR DESCRIPTION
When teleportTo subscribes to outlet$(name), the pipeline uses startWith(name) over a BehaviorSubject. On subscription both emit synchronously: startWith injects name first, then the BehaviorSubject immediately replays its current value — which is also name whenever the outlet was already registered. Both emissions pass the filter, so createEmbeddedView is called twice and the content appears duplicated in the DOM.

The same race fires on every route revisit: the service survives navigation (it's providedIn: 'root'), so the BehaviorSubject still holds the previous outlet name when the component is recreated, causing the double-emission again.

Fix: add distinctUntilChanged() at the end of the outlet$() pipeline. Since both emissions resolve to the same ViewContainerRef reference, the second is suppressed and createEmbeddedView is called exactly once.

Two regression tests are added that were failing before the fix:

- first render produces exactly one copy of the teleported content
- destroying and recreating the component (simulated route revisit) does not accumulate additional copies